### PR TITLE
chore: sync PR-review context excludes (keep SPEC.md, filter artifacts/snapshots)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,7 +103,6 @@ jobs:
             ':!package-lock.json'
             ':!yarn.lock'
             ':!**/CHANGELOG.md'
-            ':!tmp/ship/**'
             ':!dist/**'
             ':!build/**'
             ':!.next/**'
@@ -111,15 +110,27 @@ jobs:
             ':!node_modules/**'
             ':!.codex/**'
             ':!.agents/skills/pr-context/**'
-            ':!specs/**'
             ':!reports/**'
             ':!tech-probes/**'
             ':!stories/**'
             ':!projects/**'
             ':!strategy/**'
+            ':!bun.lockb'
+            ':!**/__snapshots__/**'
+            ':!*.snap'
+            ':!tmp/**'
           )
 
           BASE="origin/${{ steps.pr.outputs.base_ref }}"
+
+          # specs/ exclusion keeps SPEC.md reviewable: a feature's SPEC.md is
+          # load-bearing grounding for reviewers, while spec sub-artifacts
+          # (evidence/, meta/, analyses) are research noise. Pathspecs cannot
+          # re-include after an exclude, so enumerate changed spec files NOT
+          # named SPEC.md and exclude them by exact path.
+          while IFS= read -r spec_file; do
+            [ -n "$spec_file" ] && EXCLUDE_PATTERNS+=(":!$spec_file")
+          done < <(git diff --name-only "$BASE"...HEAD -- 'specs/' 2>/dev/null | grep -v '/SPEC\.md$' || true)
 
           DIFF=$(git diff "$BASE"...HEAD -- . "${EXCLUDE_PATTERNS[@]}")
           DIFF_SIZE=${#DIFF}
@@ -392,7 +403,6 @@ jobs:
                 ':!package-lock.json'
                 ':!yarn.lock'
                 ':!**/CHANGELOG.md'
-                ':!tmp/ship/**'
                 ':!dist/**'
                 ':!build/**'
                 ':!.next/**'
@@ -400,13 +410,22 @@ jobs:
                 ':!node_modules/**'
                 ':!.codex/**'
                 ':!.agents/skills/pr-context/**'
-                ':!specs/**'
                 ':!reports/**'
                 ':!tech-probes/**'
                 ':!stories/**'
                 ':!projects/**'
                 ':!strategy/**'
+                ':!bun.lockb'
+                ':!**/__snapshots__/**'
+                ':!*.snap'
+                ':!tmp/**'
               )
+              # Keep SPEC.md reviewable in the delta too (same rationale as
+              # EXCLUDE_PATTERNS above).
+              while IFS= read -r spec_file; do
+                [ -n "$spec_file" ] && DIFF_EXCLUDE+=(":!$spec_file")
+              done < <(git diff --name-only "$LAST_REVIEW_SHA".."$PR_HEAD" -- 'specs/' 2>/dev/null | grep -v '/SPEC\.md$' || true)
+
               SINCE_REVIEW_LOG=$(git log --oneline "$LAST_REVIEW_SHA".."$PR_HEAD")
               SINCE_REVIEW_STATS=$(git diff --stat "$LAST_REVIEW_SHA".."$PR_HEAD" -- . "${DIFF_EXCLUDE[@]}")
               SINCE_REVIEW_FILES=$(git diff --name-only "$LAST_REVIEW_SHA".."$PR_HEAD" -- . "${DIFF_EXCLUDE[@]}")


### PR DESCRIPTION
## What

Syncs this repo's PR-review workflow exclude lists with the updated team-skills template:

- **Artifact dirs excluded from auto-injected review context**: `reports/`, `tech-probes/`, `stories/`, `projects/`, `strategy/`, and all of `tmp/` — these were flowing into the cloud reviewers' diff context and burning reviewer budget on non-code content.
- **`specs/` excluded with SPEC.md kept**: spec sub-artifacts (evidence/, meta/, analyses) are filtered, but a feature's `SPEC.md` diff stays in — load-bearing grounding for understanding the change. Implemented as a dynamic per-file exclude (git pathspecs cannot re-include after an exclude).
- **Generated-file noise**: `**/__snapshots__/**`, `*.snap`, `bun.lockb`.

Both `EXCLUDE_PATTERNS` (main diff) and `DIFF_EXCLUDE` (re-review delta) updated in lockstep. Repo-specific entries preserved.

## Why

Reviewer context is token-budgeted; snapshot serializations and research artifacts are noise there. Reviewers can still Read any excluded file on demand — exclusion only affects what is auto-injected.

## Notes

- Edge case: a PR touching only excluded paths now produces an empty auto-injected diff (reviewer sees "no reviewable changes").
- Source of truth: team-skills `ci/pr-review/skills/setup-cloud-pr-reviewer/assets/claude-code-review.yml.template` (same change landing there).
- Verified: YAML parses; the SPEC.md-keep bash logic is functionally tested in team-skills (`test-generate-pr-context.sh` green; manual fixture confirmed SPEC.md hunk kept, evidence hunk filtered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)