### PR TITLE
test: fix public mirror baseline assumptions

### DIFF
--- a/packages/server/scripts/build-skill-bundles.test.ts
+++ b/packages/server/scripts/build-skill-bundles.test.ts
@@ -243,12 +243,16 @@ describe('repo assets — production guard', () => {
     expect(result.ok).toBe(true);
   });
 
-  test('every real source bundle exists and the _shared directory is present', () => {
+  test('every real source bundle exists and shared placeholders are resolvable', () => {
     const { skillsDir } = defaultPaths();
     for (const bundle of BUNDLE_IDS) {
       expect(existsSync(join(skillsDir, bundle, 'SKILL.md'))).toBe(true);
     }
-    expect(existsSync(join(skillsDir, '_shared'))).toBe(true);
+    const hasSharedSources = existsSync(join(skillsDir, '_shared'));
+    const bundlesReferenceShared = BUNDLE_IDS.some((bundle) =>
+      readFileSync(join(skillsDir, bundle, 'SKILL.md'), 'utf-8').includes('{{> _shared/'),
+    );
+    expect(hasSharedSources || !bundlesReferenceShared).toBe(true);
   });
 
   test('every bundle carries a distinct frontmatter name: value (shadow prevention)', () => {

--- a/packages/server/src/sync-engine.test.ts
+++ b/packages/server/src/sync-engine.test.ts
@@ -420,7 +420,9 @@ describe('SyncEngine ConflictStore admission (content-only)', () => {
   async function setupDivergence(remoteAction: 'modify' | 'delete'): Promise<void> {
     const bareDir = join(tmpDir, 'bare.git');
     mkdirSync(bareDir, { recursive: true });
-    await simpleGit(bareDir).init(true);
+    const bare = simpleGit(bareDir);
+    await bare.init(true);
+    await bare.raw('symbolic-ref', 'HEAD', 'refs/heads/main');
 
     const sisterDir = join(tmpDir, 'sister');
     mkdirSync(sisterDir, { recursive: true });


### PR DESCRIPTION
## Summary

- Fixes the SyncEngine conflict fixture so the bare test remote points `HEAD` at `main` before cloning.
- Adjusts the public mirror skill-bundle asset guard to require `_shared` only when source bundles still reference shared placeholders.

## Verification

- `bun test packages/server/src/sync-engine.test.ts --test-name-pattern 'SyncEngine ConflictStore admission'`
  - `3 pass / 0 fail`
- `bun test packages/server/scripts/build-skill-bundles.test.ts --test-name-pattern 'repo assets'`
  - `7 pass / 0 fail`

Verification screenshot:

![Public mirror baseline tests](https://gist.githubusercontent.com/icatw/0176c91c8c3ba8b713d354f42507f62b/raw/openknowledge-baseline-tests-verification.svg)

## Full-repo check note

This PR fixes two reproducible public-mirror baseline failures. `bun run check` is still blocked separately by `oxlint@1.66.0` panicking with `called Result::unwrap() on an Err value` / `SIGABRT` under the repo's current `oxlint.config.ts`.
