### PR TITLE
feat(cli): add GitHub Copilot CLI as an MCP install target + project skill

### DIFF
--- a/.changeset/copilot-cli-mcp-install-target.md
+++ b/.changeset/copilot-cli-mcp-install-target.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/open-knowledge": patch
+---
+
+`ok init` now installs the OpenKnowledge MCP server into the GitHub Copilot CLI. When you run `ok init` (or the desktop first-launch consent dialog) and `~/.copilot` is present, Copilot is detected alongside Claude Code, Cursor, and Codex and gets a `local` MCP entry written to `~/.copilot/mcp-config.json` (honoring `COPILOT_HOME`), with every tool pre-approved so the agent can call the OpenKnowledge `exec` tool immediately. The Copilot CLI MCP config is global only — it writes no project-local config. `ok init` also installs the project skill at `.github/skills/open-knowledge/SKILL.md` (and `ok start` keeps it refreshed), so Copilot CLI gets the same in-repo OpenKnowledge skill that Claude Code does.

--- a/docs/content/integrations/copilot.mdx
+++ b/docs/content/integrations/copilot.mdx
@@ -1,0 +1,28 @@
+---
+title: GitHub Copilot CLI
+description: Use OpenKnowledge with the GitHub Copilot CLI.
+---
+
+OpenKnowledge plugs into the [GitHub Copilot CLI](https://github.com/github/copilot-cli) through MCP.
+
+## Install
+
+<McpInstall editor="GitHub Copilot CLI" />
+
+The entry is written to your global Copilot CLI config at `~/.copilot/mcp-config.json` (or `$COPILOT_HOME/mcp-config.json` if you've set `COPILOT_HOME`). It's registered as a `local` server with every tool pre-approved (`"tools": ["*"]`), so Copilot can call the OpenKnowledge `exec` tool without an extra per-tool prompt.
+
+Unlike Claude Code, Cursor, and Codex, the Copilot CLI **MCP config** is **global only** — there's no project-local `mcp-config.json`. The single global entry applies to every project you open with `copilot`.
+
+## Project skill
+
+When you run `ok init` in a project (or `ok start`, which refreshes skills), OpenKnowledge installs a project skill at `.github/skills/open-knowledge/SKILL.md`. This is the same project skill Claude Code gets at `.claude/skills/open-knowledge/`, and it teaches the agent how to read and write OpenKnowledge content in the repo.
+
+The Copilot CLI discovers project skills from `.github/skills`, `.claude/skills`, and `.agents/skills`, so if you also select Claude Code, Cursor, or Codex during `ok init`, Copilot may see the same skill from more than one directory — that's expected and harmless.
+
+## Verify
+
+Start the Copilot CLI in your project and ask:
+
+<VerifyExec subject="Copilot CLI" />
+
+If you don't see the tool, restart the Copilot CLI so it reloads `mcp-config.json`.

--- a/docs/content/integrations/meta.json
+++ b/docs/content/integrations/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Integrations",
   "icon": "LuPlug",
-  "pages": ["claude-code", "cursor", "codex"]
+  "pages": ["claude-code", "cursor", "codex", "copilot"]
 }

--- a/packages/cli/src/commands/editors.test.ts
+++ b/packages/cli/src/commands/editors.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
 import {
+  buildCopilotServerEntry,
   buildManagedServerEntry,
   CHAIN_V1,
   CHAIN_VERSION_SENTINEL,
@@ -9,6 +11,7 @@ import {
   resolveClaudeCodeConfigPath,
   resolveClaudeDesktopConfigPath,
   resolveCodexConfigPath,
+  resolveCopilotCliConfigPath,
   resolveCursorConfigPath,
   resolveEditorTargets,
 } from './editors.ts';
@@ -141,6 +144,28 @@ describe('resolveCodexConfigPath', () => {
   });
 });
 
+describe('resolveCopilotCliConfigPath', () => {
+  it('builds the default Copilot CLI config path', () => {
+    expect(
+      resolveCopilotCliConfigPath({
+        home: '/Users/alice',
+        platformName: 'darwin',
+        env: {},
+      }),
+    ).toBe('/Users/alice/.copilot/mcp-config.json');
+  });
+
+  it('honors COPILOT_HOME when present', () => {
+    expect(
+      resolveCopilotCliConfigPath({
+        home: '/Users/alice',
+        platformName: 'darwin',
+        env: { COPILOT_HOME: '/tmp/custom-copilot-home' },
+      }),
+    ).toBe('/tmp/custom-copilot-home/mcp-config.json');
+  });
+});
+
 describe('CHAIN_V1', () => {
   it('starts with the version sentinel', () => {
     expect(CHAIN_V1.startsWith(CHAIN_VERSION_SENTINEL)).toBe(true);
@@ -225,7 +250,7 @@ describe('buildManagedServerEntry', () => {
     expect((b.args as unknown[]).length).toBe(3);
   });
 
-  it('every editor target produces the byte-identical chain entry', () => {
+  it('every chain-shaped editor target produces the byte-identical chain entry', () => {
     const editors: EditorId[] = ['claude', 'claude-desktop', 'cursor', 'codex'];
     const baseline = buildManagedServerEntry({ mode: 'published' });
     for (const id of editors) {
@@ -233,6 +258,57 @@ describe('buildManagedServerEntry', () => {
       const built = target.buildEntry('', { mode: 'published' });
       expect(built).toEqual(baseline);
     }
+  });
+});
+
+describe('buildCopilotServerEntry', () => {
+  const originalArgv1 = process.argv[1];
+  beforeEach(() => {
+    process.argv[1] = '/repo/packages/cli/src/cli.ts';
+  });
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+  });
+
+  it('wraps the published chain in a Copilot local-server envelope', () => {
+    expect(buildCopilotServerEntry({ mode: 'published' })).toEqual({
+      type: 'local',
+      command: '/bin/sh',
+      args: ['-l', '-c', CHAIN_V1],
+      tools: ['*'],
+    });
+  });
+
+  it('wraps the dev chain (preserving env) in a Copilot local-server envelope', () => {
+    expect(buildCopilotServerEntry({ mode: 'dev' })).toEqual({
+      type: 'local',
+      command: 'node',
+      args: ['/repo/packages/cli/dist/cli.mjs', 'mcp'],
+      env: { MCP_DEBUG: '1', OK_LOG_FILE: '/tmp/ok-mcp.log' },
+      tools: ['*'],
+    });
+  });
+
+  it('is the entry the copilot EDITOR_TARGET emits', () => {
+    const target = resolveEditorTargets(['copilot'])[0];
+    expect(target.buildEntry('', { mode: 'published' })).toEqual(
+      buildCopilotServerEntry({ mode: 'published' }),
+    );
+  });
+
+  it('installs a project skill at .github/skills but has no repo-local MCP config', () => {
+    const target = resolveEditorTargets(['copilot'])[0];
+    // Copilot CLI reads project skills from .github/skills (like claude-code reads
+    // .claude/skills), but it has no repo-local MCP config — only the global
+    // ~/.copilot/mcp-config.json — so projectConfigPath is intentionally undefined.
+    expect(target.projectConfigPath).toBeUndefined();
+    expect(target.projectSkillPath?.('/x')).toBe(
+      join('/x', '.github', 'skills', 'open-knowledge', 'SKILL.md'),
+    );
+  });
+
+  it('keeps the chain command/args so isEntryUpToDate still recognizes it', () => {
+    expect(isEntryUpToDate(buildCopilotServerEntry({ mode: 'published' }))).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/editors.ts
+++ b/packages/cli/src/commands/editors.ts
@@ -88,6 +88,19 @@ export function buildManagedServerEntry(options: McpInstallOptions = {}): Record
   };
 }
 
+/** GitHub Copilot CLI wraps each stdio MCP server in a `type: 'local'`
+ *  envelope and reads a `tools` allowlist (`['*']` = all tools). The launch
+ *  command/args/env are the shared managed-server chain, so Copilot stays in
+ *  lock-step with the other editors and the desktop startup repair (which only
+ *  inspects `command`/`args` via `isEntryUpToDate`). */
+export function buildCopilotServerEntry(options: McpInstallOptions = {}): Record<string, unknown> {
+  return {
+    type: 'local',
+    ...buildManagedServerEntry(options),
+    tools: ['*'],
+  };
+}
+
 interface AppSupportOptions {
   home?: string;
   platformName?: NodeJS.Platform;
@@ -162,6 +175,18 @@ export function resolveCodexConfigPath(options: AppSupportOptions = {}): string 
   return pathApiForPlatform(platformName).join(resolveCodexHomePath(options), 'config.toml');
 }
 
+function resolveCopilotHomePath(options: AppSupportOptions = {}): string {
+  const platformName = options.platformName ?? process.platform;
+  const home = options.home ?? homedir();
+  const env = options.env ?? process.env;
+  return env.COPILOT_HOME ?? pathApiForPlatform(platformName).join(home, '.copilot');
+}
+
+export function resolveCopilotCliConfigPath(options: AppSupportOptions = {}): string {
+  const platformName = options.platformName ?? process.platform;
+  return pathApiForPlatform(platformName).join(resolveCopilotHomePath(options), 'mcp-config.json');
+}
+
 export interface EditorMcpTarget {
   id: EditorId;
   label: string;
@@ -226,6 +251,21 @@ export const EDITOR_TARGETS: Record<EditorId, EditorMcpTarget> = {
     detectPath: (_cwd, home) => dirname(resolveCodexConfigPath({ home })),
     projectConfigPath: (cwd) => join(cwd, '.codex', 'config.toml'),
     projectSkillPath: (cwd) => join(cwd, '.agents', 'skills', 'open-knowledge', 'SKILL.md'),
+  },
+  copilot: {
+    id: 'copilot',
+    label: EDITOR_LABELS.copilot,
+    configPath: (_cwd, home) => resolveCopilotCliConfigPath({ home }),
+    format: 'json',
+    topLevelKey: 'mcpServers',
+    serverName: () => MCP_SERVER_NAME,
+    buildEntry: (_cwd, options) => buildCopilotServerEntry(options),
+    scope: 'global',
+    detectPath: (_cwd, home) => resolveCopilotHomePath({ home }),
+    // Copilot CLI has no repo-local MCP config (it reads only the global
+    // ~/.copilot/mcp-config.json), so there is no projectConfigPath. It does read
+    // project skills from .github/skills, so it gets a project skill like claude-code.
+    projectSkillPath: (cwd) => join(cwd, '.github', 'skills', 'open-knowledge', 'SKILL.md'),
   },
 };
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -22,6 +22,7 @@ import {
   resolveClaudeCodeConfigPath,
   resolveClaudeDesktopConfigPath,
   resolveCodexConfigPath,
+  resolveCopilotCliConfigPath,
   resolveCursorConfigPath,
 } from './editors.ts';
 
@@ -574,6 +575,9 @@ describe('runInit', () => {
       mkdirSync(dirname(resolveClaudeDesktopConfigPath({ home: fakeHome })), { recursive: true });
       mkdirSync(dirname(cursorConfigPath()), { recursive: true });
       mkdirSync(dirname(codexConfigPath()), { recursive: true });
+      mkdirSync(dirname(resolveCopilotCliConfigPath({ home: fakeHome, env: {} })), {
+        recursive: true,
+      });
 
       const result = await runInitForTest({ editors: [...ALL_EDITOR_IDS] });
 
@@ -586,6 +590,7 @@ describe('runInit', () => {
       expect(existsSync(resolveClaudeDesktopConfigPath({ home: fakeHome }))).toBe(true);
       expect(existsSync(cursorConfigPath())).toBe(true);
       expect(existsSync(codexConfigPath())).toBe(true);
+      expect(existsSync(resolveCopilotCliConfigPath({ home: fakeHome, env: {} }))).toBe(true);
     });
 
     it('overwrites across all targeted editors', async () => {
@@ -1606,11 +1611,23 @@ describe('detectInstalledEditors', () => {
     expect(detected).not.toContain('claude-desktop');
   });
 
+  it('detects Copilot CLI when ~/.copilot exists', async () => {
+    mkdirSync(join(fakeHome, '.copilot'), { recursive: true });
+    const detected = detectInstalledEditors(testDir, fakeHome);
+    expect(detected).toContain('copilot');
+  });
+
+  it('does NOT detect Copilot CLI when ~/.copilot is absent', async () => {
+    const detected = detectInstalledEditors(testDir, fakeHome);
+    expect(detected).not.toContain('copilot');
+  });
+
   it('returns all supported editors when all editor config dirs exist', async () => {
     mkdirSync(join(fakeHome, '.claude'), { recursive: true });
     mkdirSync(dirname(resolveClaudeDesktopConfigPath({ home: fakeHome })), { recursive: true });
     mkdirSync(dirname(cursorConfigPath()), { recursive: true });
     mkdirSync(dirname(codexConfigPath()), { recursive: true });
+    mkdirSync(join(fakeHome, '.copilot'), { recursive: true });
     const detected = detectInstalledEditors(testDir, fakeHome);
     expect(detected).toEqual(expect.arrayContaining([...ALL_EDITOR_IDS]));
     expect(detected).toHaveLength(ALL_EDITOR_IDS.length);
@@ -1621,8 +1638,9 @@ describe('detectInstalledEditors', () => {
     mkdirSync(dirname(resolveClaudeDesktopConfigPath({ home: fakeHome })), { recursive: true });
     mkdirSync(dirname(cursorConfigPath()), { recursive: true });
     mkdirSync(dirname(codexConfigPath()), { recursive: true });
+    mkdirSync(join(fakeHome, '.copilot'), { recursive: true });
     const detected = detectInstalledEditors(testDir, fakeHome);
-    expect(detected).toEqual(['claude', 'claude-desktop', 'cursor', 'codex']);
+    expect(detected).toEqual(['claude', 'claude-desktop', 'cursor', 'codex', 'copilot']);
   });
 
   it('returns empty list when the cwd itself does not exist (zero-detected edge case)', () => {

--- a/packages/cli/src/commands/repair-skills.ts
+++ b/packages/cli/src/commands/repair-skills.ts
@@ -28,6 +28,11 @@ const HOSTS_WITH_USER_SKILL_DIR: ReadonlyArray<{
   { hostDir: '.claude', editorId: 'claude' },
   { hostDir: '.cursor', editorId: 'cursor' },
   { hostDir: '.agents', editorId: 'codex' },
+  // Copilot CLI reads project skills from .github/skills, so that is its project
+  // host dir. It has no ~/.github user skill dir, so the user sweep reports
+  // skipped-host-absent; its user-level discovery skill is served by the central
+  // ~/.agents/skills write (Copilot CLI also reads ~/.agents/skills).
+  { hostDir: '.github', editorId: 'copilot' },
 ];
 
 const USER_SKILL_DIR_NAME = 'open-knowledge-discovery';

--- a/packages/cli/src/integrations/write-project-ai-integrations.test.ts
+++ b/packages/cli/src/integrations/write-project-ai-integrations.test.ts
@@ -54,14 +54,26 @@ describe('writeProjectAiIntegrations — installs MCP config AND the project ski
     );
   });
 
-  test('all editors: 2 outcomes per editor; claude-desktop skips both as unsupported', () => {
+  test('all editors: 2 outcomes per editor; global-only editors skip the MCP config', () => {
     const result = writeProjectAiIntegrations(projectDir, ALL_EDITOR_IDS);
 
     expect(result.integrations).toHaveLength(ALL_EDITOR_IDS.length * 2);
 
-    const desktop = result.integrations.filter((o) => o.editorId === 'claude-desktop');
-    expect(desktop).toHaveLength(2);
-    for (const outcome of desktop) expect(outcome.action).toBe('skipped-unsupported');
+    // claude-desktop is fully global-only (no project MCP config and no project
+    // skill), so both its project integrations report skipped-unsupported.
+    const claudeDesktop = result.integrations.filter((o) => o.editorId === 'claude-desktop');
+    expect(claudeDesktop).toHaveLength(2);
+    for (const outcome of claudeDesktop) expect(outcome.action).toBe('skipped-unsupported');
+
+    // Copilot CLI has no repo-local MCP config (global-only), but it DOES read a
+    // project skill from .github/skills — so the skill is written and only the
+    // MCP config is skipped.
+    const copilot = result.integrations.filter((o) => o.editorId === 'copilot');
+    expect(copilot.find((o) => o.integration === 'mcp-config')?.action).toBe('skipped-unsupported');
+    expect(copilot.find((o) => o.integration === 'project-skill')?.action).toBe('written');
+    expect(existsSync(join(projectDir, '.github', 'skills', 'open-knowledge', 'SKILL.md'))).toBe(
+      true,
+    );
   });
 
   test('empty selection returns no integrations and no launch.json', () => {

--- a/packages/cli/src/sharing/git-exclude.test.ts
+++ b/packages/cli/src/sharing/git-exclude.test.ts
@@ -47,7 +47,7 @@ describe('getOkArtifactPaths', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('returns the canonical nine-path artifact set when no config.yml exists', () => {
+  it('returns the canonical ten-path artifact set when no config.yml exists', () => {
     const paths = getOkArtifactPaths(dir);
     expect(paths).toContain(`${OK_DIR}/`);
     expect(paths).toContain('.okignore');
@@ -57,8 +57,9 @@ describe('getOkArtifactPaths', () => {
     expect(paths).toContain('.claude/skills/open-knowledge/');
     expect(paths).toContain('.cursor/skills/open-knowledge/');
     expect(paths).toContain('.agents/skills/open-knowledge/');
+    expect(paths).toContain('.github/skills/open-knowledge/');
     expect(paths).toContain('.claude/launch.json');
-    expect(paths).toHaveLength(9);
+    expect(paths).toHaveLength(10);
   });
 
   it('preserves a stable order so `ok config-sharing status` and unit-test snapshots are deterministic', () => {
@@ -76,7 +77,7 @@ describe('getOkArtifactPaths', () => {
     expect(paths).not.toContain('docs/.ok/');
     expect(paths).not.toContain('docs/.okignore');
     expect(paths.some((p) => p.includes('**'))).toBe(false);
-    expect(paths).toHaveLength(9);
+    expect(paths).toHaveLength(10);
   });
 });
 

--- a/packages/core/src/constants/editors.ts
+++ b/packages/core/src/constants/editors.ts
@@ -1,10 +1,11 @@
-export type EditorId = 'claude' | 'claude-desktop' | 'cursor' | 'codex';
+export type EditorId = 'claude' | 'claude-desktop' | 'cursor' | 'codex' | 'copilot';
 
 export const ALL_EDITOR_IDS = [
   'claude',
   'claude-desktop',
   'cursor',
   'codex',
+  'copilot',
 ] as const satisfies readonly EditorId[];
 
 export const EDITOR_LABELS = {
@@ -12,4 +13,5 @@ export const EDITOR_LABELS = {
   'claude-desktop': 'Claude Desktop',
   cursor: 'Cursor',
   codex: 'Codex',
+  copilot: 'Copilot CLI',
 } as const satisfies Record<EditorId, string>;

--- a/packages/desktop/src/main/create-new-project.test.ts
+++ b/packages/desktop/src/main/create-new-project.test.ts
@@ -463,10 +463,18 @@ describe('runCreateNew — installs the project-local skill (PRD-6733)', () => {
     expect(
       existsSync(join(result.projectDir, '.agents', 'skills', 'open-knowledge', 'SKILL.md')),
     ).toBe(true);
+    expect(
+      existsSync(join(result.projectDir, '.github', 'skills', 'open-knowledge', 'SKILL.md')),
+    ).toBe(true);
 
     const skillWrites = result.aiIntegrations.integrations.filter(
       (o) => o.integration === 'project-skill' && o.action === 'written',
     );
-    expect(skillWrites.map((o) => o.editorId).sort()).toEqual(['claude', 'codex', 'cursor']);
+    expect(skillWrites.map((o) => o.editorId).sort()).toEqual([
+      'claude',
+      'codex',
+      'copilot',
+      'cursor',
+    ]);
   });
 });

--- a/packages/desktop/src/main/skill-reclaim.ts
+++ b/packages/desktop/src/main/skill-reclaim.ts
@@ -27,6 +27,11 @@ const HOSTS_WITH_USER_SKILL_DIR: ReadonlyArray<{
   { hostDir: '.claude', editorId: 'claude' },
   { hostDir: '.cursor', editorId: 'cursor' },
   { hostDir: '.agents', editorId: 'codex' },
+  // Copilot CLI reads project skills from .github/skills, so that is its project
+  // host dir. It has no ~/.github user skill dir, so the user sweep reports
+  // skipped-host-absent; its user-level discovery skill is served by the central
+  // ~/.agents/skills write (Copilot CLI also reads ~/.agents/skills).
+  { hostDir: '.github', editorId: 'copilot' },
 ];
 
 const OK_MCP_MARKER = '# ok-mcp-v1';

--- a/packages/desktop/tests/integration/m1-smoke.test.ts
+++ b/packages/desktop/tests/integration/m1-smoke.test.ts
@@ -273,8 +273,9 @@ describe('M1 smoke', () => {
         typeName: 'EditorId',
         canonicalPath: editorsConstantPath,
         canonicalRe: /type\s+EditorId\s*=([^;]+);/,
-        expectedLiteralCount: 4,
-        inlineRe: /'claude'\s*\|\s*'claude-desktop'\s*\|\s*'cursor'\s*\|\s*'codex'/,
+        expectedLiteralCount: 5,
+        inlineRe:
+          /'claude'\s*\|\s*'claude-desktop'\s*\|\s*'cursor'\s*\|\s*'codex'\s*\|\s*'copilot'/,
         mirrors: [
           ['cli/commands/editors.ts', cliEditorsPath],
           ['desktop/shared/ipc-channels.ts', ipcChannelsPath],


### PR DESCRIPTION
## What & why

OpenKnowledge wired up MCP install targets and project skills for Claude Code, Cursor, and Codex, but not GitHub Copilot CLI, even though Copilot CLI speaks MCP and supports skills. This adds `copilot` (label "Copilot CLI") as a first-class editor target so Copilot users get the same out-of-the-box integration: `ok init` registers the OpenKnowledge MCP server and installs the in-repo project skill, and `ok start` keeps the skill refreshed.

The change leans on the existing data-driven `EDITOR_TARGETS` registry, so most of it is one new target plus registration in the skill-repair sweeps.

- **MCP target:** writes a `local` server entry to the global `~/.copilot/mcp-config.json` (honoring `COPILOT_HOME`) with `tools: ["*"]` so the agent can call the OpenKnowledge `exec` tool without a per-tool prompt.
- **Project skill:** installs at `.github/skills/open-knowledge/SKILL.md` (the same skill Claude Code gets at `.claude/skills/`), registered in both the CLI (`repair-skills.ts`) and Desktop (`skill-reclaim.ts`) sweeps so `ok start` reclaims/refreshes it.

**Follows the claude-code pattern, not claude-desktop.** Copilot gets the project skill like claude-code, but intentionally has **no `projectConfigPath`** because Copilot CLI's MCP config is authoritatively global-only (there is no repo-local `.mcp.json` equivalent). That is a real Copilot capability difference, not the global-everything claude-desktop model.

A couple of non-obvious points worth a reviewer's eye:

- **Project/user skill dir asymmetry:** Copilot reads project skills from `.github/skills` but personal skills from `~/.copilot` or `~/.agents`. The user-level discovery skill is already served by the central `~/.agents/skills/open-knowledge-discovery/` write (Copilot reads `.agents`), so no dedicated `~/.copilot` discovery skill is written, deliberately avoiding a duplicate skill name.
- **Cross-dir duplication is expected/harmless:** if a user selects both Claude and Copilot, the project skill lands in `.claude/skills` and `.github/skills`, both of which Copilot reads. Documented as such in `copilot.mdx`.

The outbound "Open with AI" / "Edit with AI" handoff launcher is **not** part of this PR (still `claude`/`cursor`/`codex` only); this is inbound MCP + skill only.

## How this was verified

- `bun run check` (lint, build, typecheck, tests) run locally. All suites pass except two pre-existing/unrelated desktop failures confirmed on `main` as well (an IPC channel-count ratchet marker and a PTY-flood stress test that only times out under full parallel load and passes in isolation).
- Updated the enumeration-driven tests that assert per-editor behavior: `editors.test.ts`, `write-project-ai-integrations.test.ts` (copilot writes the project skill, skips MCP config; only claude-desktop skips both), `git-exclude.test.ts` (canonical artifact set 9 -> 10), and desktop `create-new-project.test.ts` (skill writes now include `copilot`).
- Rebuilt the CLI dist that Desktop consumes.

## Checklist

- [x] Ran `bun run check` (lint, typecheck, tests) locally
- [x] Added a changeset (`bun run changeset`) if this changes behavior
- [x] Updated docs if this changes a user-facing surface
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to license my contribution under the project's terms (CLA)
