### PR TITLE
Update warning message in GitHub sync documentation

### DIFF
--- a/docs/content/features/github-sync.mdx
+++ b/docs/content/features/github-sync.mdx
@@ -6,7 +6,7 @@ description: Clone repos from GitHub, auto-sync changes with your team, and reso
 OpenKnowledge can connect a project to a GitHub remote repository and keep it synced over time. When GitHub sync is enabled, OpenKnowledge actively pulls commits from the remote and pushes commits back.
 
 <Callout type="warn">
-  Only enable GitHub sync for repositories where you are comfortable with OpenKnowledge writing commits to the remote history. If you are worried about automated commits corrupting or cluttering your Git history, do not enable sync for that repository.
+  Only enable GitHub sync for repositories where you are comfortable with OpenKnowledge writing commits to the remote history. If you are worried about automated commits cluttering your Git history, do not enable sync for that repository.
 </Callout>
 
 ## What GitHub sync is for


### PR DESCRIPTION
Removed the word 'corrupting' from the warning about enabling GitHub sync.

## What & why

<!-- One or two sentences on the change and the motivation. Link any related issue. -->

## How this was verified

<!-- How you tested: `bun run check` output, manual steps, before/after screenshots for UI changes. -->

## Checklist

- [ ] Ran `bun run check` (lint, typecheck, tests) locally
- [ ] Added a changeset (`bun run changeset`) if this changes behavior
- [ ] Updated docs if this changes a user-facing surface
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to license my contribution under the project's terms (CLA)

---

### After you open this PR

- A maintainer will review your PR. If you don't hear back within a few business days, a comment to nudge is welcome.
- When your change is accepted, this PR closes automatically — that's how it merges, and your authorship is preserved.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
