### PR TITLE
Update installation instructions for Claude Code

### DIFF
--- a/docs/content/integrations/claude-code.mdx
+++ b/docs/content/integrations/claude-code.mdx
@@ -13,8 +13,6 @@ OpenKnowledge works with Claude Code through MCP plus an installed skill that te
 
 <McpInstall editor="Claude Code" />
 
-If you installed the OpenKnowledge desktop app from the macOS DMG, a consent dialog runs on first launch and offers to wire up the MCP-capable agents it detects, Claude Code included — click **Add**. To re-trigger it, delete `~/.ok/mcp-status.json` and relaunch.
-
 ## Open with AI
 
 From the editor, **Open with AI ▸ Claude** dispatches the current file, folder, or project to Claude Code in one click. Two entry points: the sidebar's right-click menu (file / folder / empty space) and the macOS **File → Open with AI** menu. You can also hand the current doc to Claude from the bottom **Ask AI** composer.


### PR DESCRIPTION
Removed instructions for re-triggering consent dialog for MCP-capable agents. It is redundant.

## What & why

<!-- One or two sentences on the change and the motivation. Link any related issue. -->

## How this was verified

<!-- How you tested: `bun run check` output, manual steps, before/after screenshots for UI changes. -->

## Checklist

- [ ] Ran `bun run check` (lint, typecheck, tests) locally
- [ ] Added a changeset (`bun run changeset`) if this changes behavior
- [ ] Updated docs if this changes a user-facing surface
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to license my contribution under the project's terms (CLA)

---

### After you open this PR

- A maintainer will review your PR. If you don't hear back within a few business days, a comment to nudge is welcome.
- When your change is accepted, this PR closes automatically — that's how it merges, and your authorship is preserved.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
