### PR TITLE
fix(server): include symbolic links in sync walker to prevent deletion

### DIFF
--- a/.changeset/prevent-staging-symlink-deletion.md
+++ b/.changeset/prevent-staging-symlink-deletion.md
@@ -1,0 +1,5 @@
+---
+"@inkeep/open-knowledge": patch
+---
+
+Fixed symbolic links (mode `120000`) being automatically staged as deleted in the background Git sync loop. The filesystem scanner now correctly walks and includes symbolic links inside the content directory so they are recognized as on-disk files and are not incorrectly removed from Git tracking during sync commits.

--- a/packages/server/src/sync-engine.ts
+++ b/packages/server/src/sync-engine.ts
@@ -1846,7 +1846,7 @@ export class SyncEngine {
           if (!dirRelPath.startsWith('..') && this.contentFilter.isDirExcluded(dirRelPath))
             continue;
           walk(fullPath);
-        } else if (entry.isFile()) {
+        } else if (entry.isFile() || entry.isSymbolicLink()) {
           const contentRelPath = toPosix(relative(this.contentDir, fullPath));
           // Only include files inside contentDir that pass the filter
           if (!contentRelPath.startsWith('..') && !this.contentFilter.isExcluded(contentRelPath)) {


### PR DESCRIPTION
Closes https://github.com/inkeep/open-knowledge/issues/548

## What & why

In an OpenKnowledge project, if you have symbolic links in your git repo (e.g. to avoid duplicate pages), the OpenKnowledge background auto-save sync process will automatically stage and commit these symlinks as deleted (delete mode 120000 in Git) during its background synchronization sweep.

Crucially, the sync engine only updates Git's index and does not delete the physical symlink files from the local filesystem. This results in the symlink files permanently showing up as Untracked under git status right after the first auto-save runs.

## How this was verified

<!-- How you tested: `bun run check` output, manual steps, before/after screenshots for UI changes. -->

## Checklist

- [x] Ran `bun run check` (lint, typecheck, tests) locally
- [x] Added a changeset (`bun run changeset`) if this changes behavior
- [x] Updated docs if this changes a user-facing surface
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to license my contribution under the project's terms (CLA)

---

### After you open this PR

- A maintainer will review your PR. If you don't hear back within a few business days, a comment to nudge is welcome.
- When your change is accepted, this PR closes automatically — that's how it merges, and your authorship is preserved.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
