### PR TITLE
docs: add changeset instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,11 @@ Run a single package's scripts from its directory, e.g. `cd packages/app && bun 
 
 ## Opening a pull request
 
-First-time contributors are asked to sign our [Contributor License Agreement](./CLA.md) — a bot comments a one-click signing link on your PR (Inkeep employees are exempt automatically).
+First-time contributors are asked to sign our [Contributor License Agreement](./CLA.md) — a bot comments a one-click signing link on your PR (Inkeep employees are exempt automatically). Please follow the checklist in our [Pull Request Template](./.github/PULL_REQUEST_TEMPLATE.md):
 
 - Keep PRs focused and small enough to review.
 - Add tests — or a clear manual-verification note — for behavior changes.
+- Add a changeset by running `bun run changeset` if your pull request changes user-facing or programmatic behavior.
 - Run `bun run check` and confirm it passes.
 - Commit `bun.lock` when dependencies change, and run `bun run notices` to refresh `THIRD_PARTY_NOTICES.md` if third-party packages changed.
 - Never include secrets, credentials, customer data, or local machine paths.


### PR DESCRIPTION
## What & why

CONTRIBUTING.md did not mention the changeset, so a contributor first hears of this when drafting their PR, resulting in rework.

## How this was verified

Docs update.

## Checklist

- [NA] Ran `bun run check` (lint, typecheck, tests) locally
- [NA] Added a changeset (`bun run changeset`) if this changes behavior
- [NA] Updated docs if this changes a user-facing surface
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to license my contribution under the project's terms (CLA)

---

### After you open this PR

- A maintainer will review your PR. If you don't hear back within a few business days, a comment to nudge is welcome.
- When your change is accepted, this PR closes automatically — that's how it merges, and your authorship is preserved.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
