### PR TITLE
feat: add Web Clipper intake protocol (openknowledge://clip) and clip-intake schema (#1174)

### DIFF
--- a/.changeset/add-web-clipper-intake-protocol.md
+++ b/.changeset/add-web-clipper-intake-protocol.md
@@ -1,0 +1,5 @@
+---
+'@inkeep/open-knowledge': patch
+---
+
+add Web Clipper intake protocol (`openknowledge://clip`) and `openknowledge.clip/v1` payload schema for one-click browser capture.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -882,6 +882,8 @@ export {
   ContentDivergenceCurrentStateSchema,
   type ContentDivergenceWarning,
   ContentDivergenceWarningSchema,
+  ClipPayloadSchema,
+  type OkClipPayload,
   type CreateFolderRequest,
   CreateFolderRequestSchema,
   type CreateFolderSuccess,

--- a/packages/core/src/schemas/api/clip-intake.ts
+++ b/packages/core/src/schemas/api/clip-intake.ts
@@ -1,0 +1,23 @@
+/**
+ * Web Clipper clip-intake envelope schema (`openknowledge.clip/v1`).
+ *
+ * Validates the clip payload passed from browser extensions via the clipboard
+ * during the `openknowledge://clip?destination=<id>&clipboard=true` intake flow.
+ */
+
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { z } from 'zod';
+
+export const ClipPayloadSchema = z
+  .object({
+    schema: z.literal('openknowledge.clip/v1'),
+    title: z.string().min(1),
+    suggestedFilename: z.string().min(1).optional(),
+    sourceUrl: z.string().min(1),
+    selectionOnly: z.boolean().default(false),
+    markdown: z.string(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+  .loose() satisfies StandardSchemaV1;
+
+export type OkClipPayload = z.infer<typeof ClipPayloadSchema>;

--- a/packages/core/src/schemas/api/index.ts
+++ b/packages/core/src/schemas/api/index.ts
@@ -22,6 +22,7 @@
 export * from './_envelope.ts';
 export * from './agent-write.ts';
 export * from './client-logs.ts';
+export * from './clip-intake.ts';
 export * from './comments.ts';
 export * from './document-read.ts';
 export * from './embed-detect.ts';

--- a/packages/desktop/src/main/clip-intake.ts
+++ b/packages/desktop/src/main/clip-intake.ts
@@ -1,0 +1,58 @@
+/**
+ * Desktop clip intake helpers for Web Clipper payload processing.
+ *
+ * Implements filename sanitization, traversal prevention, and deterministic
+ * collision resolution ("Keep both") for clipped documents.
+ */
+
+import { basename, extname } from 'node:path';
+
+/**
+ * Sanitize a suggested filename or title for a clipped document.
+ * Strips directory traversal, invalid characters, null bytes, and forces
+ * a `.md` extension.
+ */
+export function sanitizeClipFilename(suggestedFilename?: string, title?: string): string {
+  const candidate = (suggestedFilename ?? title ?? 'clipped-document').trim();
+  // Strip path segments using basename first, then replace forbidden filename characters
+  let clean = basename(candidate)
+    .replace(/[\x00-\x1f\x7f<>:"/\\|?*]/g, '-')
+    .replace(/^(?:\.\.+[/\\|]?)+/, '')
+    .trim();
+
+  if (clean.length === 0 || clean === '.' || clean === '..') {
+    clean = 'clipped-document';
+  }
+
+  const ext = extname(clean).toLowerCase();
+  if (ext !== '.md' && ext !== '.mdx') {
+    clean = `${clean}.md`;
+  }
+
+  return clean;
+}
+
+/**
+ * Resolve a non-colliding filename when a document with the target name already exists.
+ * Implements the "Keep both" collision policy (e.g., `article.md` -> `article-1.md`).
+ */
+export function resolveNonCollidingFilename(
+  existingDocNames: ReadonlySet<string>,
+  targetFilename: string,
+): string {
+  if (!existingDocNames.has(targetFilename)) {
+    return targetFilename;
+  }
+
+  const ext = extname(targetFilename);
+  const stem = targetFilename.slice(0, targetFilename.length - ext.length);
+
+  let counter = 1;
+  let candidate = `${stem}-${counter}${ext}`;
+  while (existingDocNames.has(candidate)) {
+    counter += 1;
+    candidate = `${stem}-${counter}${ext}`;
+  }
+
+  return candidate;
+}

--- a/packages/desktop/src/main/url-scheme-clip.test.ts
+++ b/packages/desktop/src/main/url-scheme-clip.test.ts
@@ -1,0 +1,78 @@
+import { ClipPayloadSchema } from '@inkeep/open-knowledge-core';
+import { describe, expect, test } from 'vitest';
+import { resolveNonCollidingFilename, sanitizeClipFilename } from './clip-intake.ts';
+import { parseClipUrl } from './url-scheme.ts';
+
+describe('parseClipUrl', () => {
+  test('parses a valid clip intake URL', () => {
+    const parsed = parseClipUrl('openknowledge://clip?destination=default_inbox&clipboard=true');
+    expect(parsed).toEqual({
+      host: 'clip',
+      destination: 'default_inbox',
+      clipboard: true,
+    });
+  });
+
+  test('rejects missing destination', () => {
+    expect(parseClipUrl('openknowledge://clip?clipboard=true')).toBeNull();
+  });
+
+  test('rejects null bytes', () => {
+    expect(parseClipUrl('openknowledge://clip?destination=inbox%00bad&clipboard=true')).toBeNull();
+    expect(parseClipUrl('openknowledge://clip?destination=inbox\x00bad&clipboard=true')).toBeNull();
+  });
+
+  test('rejects path traversal in destination ID', () => {
+    expect(parseClipUrl('openknowledge://clip?destination=../etc/passwd&clipboard=true')).toBeNull();
+  });
+
+  test('rejects invalid scheme or host', () => {
+    expect(parseClipUrl('https://clip?destination=inbox')).toBeNull();
+    expect(parseClipUrl('openknowledge://open?destination=inbox')).toBeNull();
+  });
+});
+
+describe('ClipPayloadSchema', () => {
+  test('validates openknowledge.clip/v1 envelope', () => {
+    const payload = {
+      schema: 'openknowledge.clip/v1',
+      title: 'Test Article',
+      suggestedFilename: 'test-article.md',
+      sourceUrl: 'https://example.com/test',
+      selectionOnly: false,
+      markdown: '# Test Article\n\nContent...',
+      metadata: { author: 'Alice' },
+    };
+
+    const parsed = ClipPayloadSchema.safeParse(payload);
+    expect(parsed.success).toBe(true);
+  });
+
+  test('rejects wrong schema version', () => {
+    const payload = {
+      schema: 'openknowledge.clip/v2',
+      title: 'Test Article',
+      sourceUrl: 'https://example.com/test',
+      markdown: 'Content',
+    };
+
+    const parsed = ClipPayloadSchema.safeParse(payload);
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('clip-intake filename sanitization and collision resolution', () => {
+  test('sanitizes titles into clean .md filenames', () => {
+    expect(sanitizeClipFilename('My Article', '')).toBe('My Article.md');
+    expect(sanitizeClipFilename(undefined, 'Raw Title: With Special Chars?')).toBe(
+      'Raw Title- With Special Chars-.md',
+    );
+    expect(sanitizeClipFilename('../../etc/passwd')).toBe('passwd.md');
+  });
+
+  test('resolves non-colliding filenames ("Keep both")', () => {
+    const existing = new Set(['article.md', 'article-1.md']);
+    expect(resolveNonCollidingFilename(existing, 'article.md')).toBe('article-2.md');
+    expect(resolveNonCollidingFilename(existing, 'new-article.md')).toBe('new-article.md');
+  });
+});

--- a/packages/desktop/src/main/url-scheme.ts
+++ b/packages/desktop/src/main/url-scheme.ts
@@ -434,6 +434,54 @@ export function parseOpenKnowledgeFileUrl(input: string): ParsedOpenKnowledgeFil
   return { host: 'open', file: resolve(file) };
 }
 
+/** Parsed `openknowledge://clip?destination=<id>` clip-intake deep-link. */
+export interface ParsedClipUrl {
+  readonly host: 'clip';
+  readonly destination: string;
+  readonly clipboard: boolean;
+}
+
+/**
+ * Parse + validate the Web Clipper clip-intake deep-link
+ * `openknowledge://clip?destination=<id>&clipboard=true`.
+ * Returns `null` on any validation failure (missing param, null bytes,
+ * invalid host, `..` traversal in destination ID); never throws.
+ */
+export function parseClipUrl(input: string): ParsedClipUrl | null {
+  if (typeof input !== 'string' || input.length === 0) return null;
+  if (input.includes('\x00') || /%00/i.test(input)) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'openknowledge:') return null;
+  if (parsed.hostname !== 'clip') return null;
+
+  const rawDestination = parsed.searchParams.get('destination');
+  if (!rawDestination) return null;
+
+  let destination: string;
+  try {
+    destination = decodeURIComponent(rawDestination);
+  } catch {
+    return null;
+  }
+
+  if (destination.includes('\x00') || destination.length === 0) return null;
+  if (destination.split(/[/\\]/).includes('..')) return null;
+
+  const clipboard = parsed.searchParams.get('clipboard') === 'true';
+
+  return {
+    host: 'clip',
+    destination,
+    clipboard,
+  };
+}
+
 /**
  * Named app screens reachable via `openknowledge://screen?name=<id>`. Each maps
  * to a renderer URL-hash route (`window.location.hash`, handled in `App.tsx`)


### PR DESCRIPTION
Resolves inkeep/open-knowledge#1174

### Description

This PR introduces the secure **Web Clipper Desktop Intake Protocol** (`openknowledge://clip`) and `openknowledge.clip/v1` envelope schema as proposed in #1174.

### What Changed

- **Core Package (`packages/core`)**:
  - Added `ClipPayloadSchema` and `OkClipPayload` in `packages/core/src/schemas/api/clip-intake.ts` validating `openknowledge.clip/v1` Markdown envelopes.
  - Re-exported `ClipPayloadSchema` in core API schemas.
- **Desktop Package (`packages/desktop`)**:
  - Added `parseClipUrl` in `packages/desktop/src/main/url-scheme.ts` to parse and validate `openknowledge://clip?destination=<id>&clipboard=true` deep links with path traversal and null-byte defenses.
  - Created `packages/desktop/src/main/clip-intake.ts` providing filename sanitization and "Keep both" collision resolution (`article.md` -> `article-1.md`).
- **Tests & Changeset**:
  - Added comprehensive unit tests in `packages/desktop/src/main/url-scheme-clip.test.ts` (9/9 tests passing).
  - Included changeset `.changeset/add-web-clipper-intake-protocol.md`.

### Testing

- Ran `npx vitest run src/main/url-scheme-clip.test.ts` (all 9 unit tests passed).
- Verified `parseClipUrl` rejects null-bytes, missing destinations, invalid hosts, and path traversal attempts.
