### PR TITLE
fix(server): serialize chokidar watcher batches to prevent heap growth

### DIFF
--- a/.changeset/chokidar-batch-serialization.md
+++ b/.changeset/chokidar-batch-serialization.md
@@ -1,0 +1,5 @@
+---
+'@inkeep/open-knowledge': patch
+---
+
+Fix unbounded heap growth of the chokidar file watcher fallback on Windows. Batches are now drained strictly one at a time, so event storms no longer pile up overlapping async work.

--- a/packages/server/src/file-watcher-chokidar-fallback.test.ts
+++ b/packages/server/src/file-watcher-chokidar-fallback.test.ts
@@ -272,3 +272,61 @@ describe('chokidar backend — templates-as-content watching (forceBackend)', ()
     }
   });
 });
+
+describe('chokidar backend — batch serialization', () => {
+  // Regression for the Windows heap-growth bug: chokidar (ReadDirectoryChangesW)
+  // emits more granular events than inotify, so a 50ms batch can still be
+  // mid-drain (readFile-ing every change) when the next timer fires. Without
+  // serialization each timer fire launches handleRawEvents independently and
+  // overlapping batches pile up → unbounded heap growth on event storms.
+  let tmpDir: string;
+  let contentDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(resolve(tmpdir(), 'ok-chokidar-serial-'));
+    contentDir = resolve(tmpDir, 'content');
+    mkdirSync(contentDir, { recursive: true });
+    writeFileSync(resolve(contentDir, 'seed.md'), '# Seed\n');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function until(predicate: () => boolean, timeoutMs = 4000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (predicate()) return true;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    return predicate();
+  }
+
+  test('batches are drained strictly one at a time', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const filter = createContentFilter({ projectDir: tmpDir, contentDir });
+    const handle = await startWatcher(
+      contentDir,
+      async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 200));
+        active--;
+      },
+      filter,
+      { forceBackend: 'chokidar' },
+    );
+    try {
+      // Batch 1: write to an existing file → watcher fires, drain starts.
+      writeFileSync(resolve(contentDir, 'seed.md'), '# Seed 1\n');
+      expect(await until(() => active === 1)).toBe(true);
+      // Batch 2 lands mid-drain (drain holds 200ms) → must queue, not overlap.
+      writeFileSync(resolve(contentDir, 'seed.md'), '# Seed 2\n');
+      await new Promise((r) => setTimeout(r, 600));
+      expect(maxActive).toBe(1);
+    } finally {
+      await handle.unsubscribe();
+    }
+  });
+});

--- a/packages/server/src/file-watcher.ts
+++ b/packages/server/src/file-watcher.ts
@@ -2093,6 +2093,12 @@ async function startChokidarWatcher(
   const BATCH_WINDOW_MS = 50;
   let pendingEvents: Array<{ type: 'create' | 'update' | 'delete'; path: string }> = [];
   let batchTimer: ReturnType<typeof setTimeout> | null = null;
+  // Serialize batches: chokidar (Windows ReadDirectoryChangesW) emits more
+  // granular events than inotify, so a 50ms batch can still be mid-drain
+  // (readFile-ing every change) when the next timer fires. Launching batches
+  // independently piles up overlapping async work → unbounded heap growth on
+  // event storms. Chaining on this promise makes batches strictly sequential.
+  let inFlight: Promise<void> = Promise.resolve();
 
   function queueEvent(type: 'create' | 'update' | 'delete', path: string) {
     pendingEvents.push({ type, path });
@@ -2101,15 +2107,18 @@ async function startChokidarWatcher(
       pendingEvents = [];
       batchTimer = null;
       onRawBatch?.(batch.map((e) => e.path));
-      handleRawEvents(
-        batch,
-        contentDir,
-        contentFilter,
-        fileIndex,
-        folderIndex,
-        onDiskEvent,
-        aliasMap,
-      )
+      inFlight = inFlight
+        .then(() =>
+          handleRawEvents(
+            batch,
+            contentDir,
+            contentFilter,
+            fileIndex,
+            folderIndex,
+            onDiskEvent,
+            aliasMap,
+          ),
+        )
         .then(onAfterMutation)
         .catch((err) => log.error({ err }, 'chokidar batch error'));
     }, BATCH_WINDOW_MS);


### PR DESCRIPTION
## Problem

On Windows the OK server uses the chokidar watcher fallback (`@parcel/watcher` crashes with `STATUS_STACK_BUFFER_OVERRUN` on long/non-ASCII paths, see #1207). chokidar (ReadDirectoryChangesW) emits more granular events than inotify, and each 50ms batch calls `handleRawEvents`, which readFile()s every changed file.

When a batch is still mid-drain (slow disk, many files, active sync/backup tool) and the next 50ms timer fires, the new batch launches independently — overlapping async work piles up and the Node heap grows without bound on event storms.

## Fix

Serialize batches by chaining them on an `inFlight` promise in `startChokidarWatcher`. Batches drain strictly one at a time; a batch that lands while another is draining waits its turn. The `.catch` remains load-bearing: it keeps the chain alive after an error so later batches don't deadlock.

## Regression test

`file-watcher-chokidar-fallback.test.ts` — new describe "chokidar backend — batch serialization":
- onDiskEvent counts active drains (`active++`, hold 200ms, `active--`), tracks `maxActive`
- write to existing file → wait until `active === 1` (batch 1 draining)
- write again → batch 2 lands mid-drain
- wait 600ms, `expect(maxActive).toBe(1)`

Verified:
- **Without fix:** test fails (`maxActive` reaches 2 — batches overlap)
- **With fix:** 11/11 tests pass, typecheck clean

Tested with `forceBackend: 'chokidar'` on Linux — no Windows needed to exercise the path.