### PR TITLE
fix(server): cap telemetry sink append backlog to prevent unbounded heap growth

### DIFF
--- a/.changeset/telemetry-sink-backlog-cap.md
+++ b/.changeset/telemetry-sink-backlog-cap.md
@@ -1,0 +1,9 @@
+---
+'@inkeep/open-knowledge': patch
+---
+
+Bound the telemetry sink's append backlog so a span storm can't balloon memory
+
+`RotatingAppender` serialized writes through an unbounded promise chain. Under `SimpleSpanProcessor`, seeding a large workspace ends one span per file — tens of thousands of spans enqueue faster than serial disk appends can drain them, and each queued link pinned its payload plus chain closures until every predecessor settled. On ~34k-file projects this grew the heap by multiple GB during startup ("memory growth after parsing finished").
+
+Queued appends are now capped at 1000 per sink path; beyond the cap, appends are rejected instead of queued (mirroring the SDK's own `maxQueueSize` drop policy). These sinks are local diagnostics, so losing records under sustained overload beats unbounded memory growth.

--- a/packages/server/src/telemetry-file-sink.test.ts
+++ b/packages/server/src/telemetry-file-sink.test.ts
@@ -351,6 +351,41 @@ describe('RotatingAppender (shared rotation primitive)', () => {
     expect(readFileSync(currentPath, 'utf-8')).toBe('1\n2\n3\n');
   });
 
+  // Backlog cap: when the sink can't keep up (span storm), appends beyond the
+  // cap are dropped with a rejection instead of queueing unboundedly. Each
+  // queued link pins its payload until all predecessors settle, so an
+  // unbounded backlog is a memory bug (multi-GB heap growth on large seeds).
+  // The dropped append must NOT enter the chain: later appends still land in
+  // order and the chain stays healthy.
+  test('drops appends past the pending cap; later appends still land in order', async () => {
+    const currentPath = join(tmp, 'backlog-cap', 'e-current.jsonl');
+    const previousPath = join(tmp, 'backlog-cap', 'e-prev.jsonl');
+    const appender = new RotatingAppender({
+      currentPath,
+      previousPath,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+    });
+
+    // Fire 1500 appends synchronously — faster than serial disk writes can
+    // drain them, so the queue genuinely backs up past MAX_PENDING_APPENDS.
+    const settled = await Promise.allSettled(
+      Array.from({ length: 1500 }, (_, i) => appender.append(`line-${i}\n`)),
+    );
+
+    const dropped = settled.filter((s) => s.status === 'rejected');
+    const written = settled.filter((s) => s.status === 'fulfilled');
+    expect(written.length).toBeGreaterThan(0);
+    expect(dropped.length).toBeGreaterThan(0);
+    expect(written.length + dropped.length).toBe(1500);
+    // Every written line is intact and in enqueue order — no corruption.
+    const lines = readFileSync(currentPath, 'utf-8').trim().split('\n');
+    expect(lines.length).toBe(1500 - dropped.length);
+    for (let i = 0; i < lines.length; i++) expect(lines[i]).toMatch(/^line-\d+$/);
+    // Chain still healthy: a post-storm append lands normally.
+    await appender.append('after\n');
+    expect(readFileSync(currentPath, 'utf-8').endsWith('after\n')).toBe(true);
+  });
+
   // Invariant A: rotation is safe across EVERY writer to a path, not just
   // within one appender instance. In production each getLogger(name) allocates
   // its own PinoFileSink → its own RotatingAppender on the shared log path, so

--- a/packages/server/src/telemetry-file-sink.ts
+++ b/packages/server/src/telemetry-file-sink.ts
@@ -45,7 +45,20 @@ export interface RotatingAppenderOpts {
 interface PathWriteState {
   chain: Promise<unknown>;
   parentDirEnsured: boolean;
+  /** Appends enqueued but not yet written; bounded by MAX_PENDING_APPENDS. */
+  pending: number;
 }
+
+/**
+ * Ceiling on queued-but-unwritten appends per path. Under SimpleSpanProcessor a
+ * seed walk over tens of thousands of files ends spans faster than serial disk
+ * appends can drain them; each queued link holds its payload plus the promise
+ * chain, so an unbounded backlog grew into multi-GB heaps (DESAP10-class).
+ * Beyond the cap, appends are dropped: these sinks are local diagnostics, so
+ * losing records under sustained overload beats unbounded memory. This mirrors
+ * the SDK's own BatchSpanProcessor maxQueueSize drop policy.
+ */
+const MAX_PENDING_APPENDS = 1000;
 
 /**
  * Serialization state keyed by `currentPath`. Rotation must be serialized per
@@ -73,7 +86,7 @@ const pathWriteState = new Map<string, PathWriteState>();
 function getPathWriteState(currentPath: string): PathWriteState {
   let state = pathWriteState.get(currentPath);
   if (!state) {
-    state = { chain: Promise.resolve(), parentDirEnsured: false };
+    state = { chain: Promise.resolve(), parentDirEnsured: false, pending: 0 };
     pathWriteState.set(currentPath, state);
   }
   return state;
@@ -109,12 +122,27 @@ export class RotatingAppender {
    * underlying fs error if either step fails.
    */
   append(data: string | Uint8Array): Promise<void> {
+    // Drop instead of queue when the disk can't keep up: each queued link pins
+    // its payload + a promise-chain link until every predecessor's write
+    // settles, so an unbounded backlog under span storms is the memory bug this
+    // cap exists for. Diagnostics data, so loss beats unbounded heap growth.
+    if (this.#state.pending >= MAX_PENDING_APPENDS) {
+      return Promise.reject(
+        new Error(
+          `RotatingAppender: backlog over ${MAX_PENDING_APPENDS} appends for ${this.#currentPath}; append dropped`,
+        ),
+      );
+    }
+    this.#state.pending++;
     const next = this.#state.chain
       // Swallow prior errors so one bad write doesn't deadlock the chain;
       // the rejection still surfaced to that call's awaiter via its own
       // returned promise.
       .catch(() => undefined)
-      .then(() => this.#doAppend(data));
+      .then(() => this.#doAppend(data))
+      .finally(() => {
+        this.#state.pending--;
+      });
     this.#state.chain = next;
     return next;
   }


### PR DESCRIPTION
## Problem

`RotatingAppender` serialized writes through an **unbounded promise chain**. Under `SimpleSpanProcessor`, seeding a large workspace ends one telemetry span per file — tens of thousands of spans enqueue faster than serial disk appends can drain them, and each queued link pinned its payload plus chain closures until every predecessor settled.

Observed on a ~34k-file workspace: multi-GB heap growth during startup, continuing after parsing finished (the memory-growth reports in the wild).

## Fix

Queued appends are now capped at **1000 per sink path**; beyond the cap, appends are rejected instead of queued — mirroring the OTel SDK's own `maxQueueSize` drop policy. These sinks are local diagnostics: losing records under sustained overload beats unbounded memory growth.

## Changes
- `packages/server/src/telemetry-file-sink.ts` — `pending` counter + `MAX_PENDING_APPENDS` cap in `RotatingAppender`
- `packages/server/src/telemetry-file-sink.test.ts` — test that excess appends are dropped while later appends still land in order
- `.changeset/telemetry-sink-backlog-cap.md`

## Verification
- `vitest packages/server/src/telemetry-file-sink.test.ts`: 30/30 passed
- `tsc --noEmit` (packages/server): clean